### PR TITLE
Allow spread to be 0 without defaulting to 'u'

### DIFF
--- a/src/points.js
+++ b/src/points.js
@@ -61,7 +61,7 @@ const render_zone = exports._render_zone = (zone_name, zone, anchor, global_key,
             'number'
         )(units)
         col.spread = a.sane(
-            col.spread || (first_col ? 0 : 'u'),
+            col.spread !== undefined ? col.spread : (first_col ? 0 : 'u'),
             `points.zones.${zone_name}.columns.${col_name}.spread`,
             'number'
         )(units)


### PR DESCRIPTION
Currently when `spread: 0` is used this is interpreted as falsy by the `||` operator used within the `.sane` function
This causes `spread: 0` to default to `spread: u` on most columns

I realise this is not a future that any layout would realistically use, and it can be worked around.
However I would consider allowing `0` as new users trying out parameters may do this to see how this parameter affects the layout

Is this a scenario you'd want to allow or was this intended?
Thanks!