### PR TITLE
Fix scrollwheel footprint WebUI error

### DIFF
--- a/src/footprints/scrollwheel.js
+++ b/src/footprints/scrollwheel.js
@@ -34,7 +34,7 @@ module.exports = {
 		  reverse: false
     },
     body: p => {
-      standard = `
+      const standard = `
         (module RollerEncoder_Panasonic_EVQWGD001 (layer F.Cu) (tedit 6040A10C)
         ${p.at /* parametric position */}   
         (fp_text reference REF** (at 0 0 ${p.rot}) (layer F.Fab) (effects (font (size 1 1) (thickness 0.15))))


### PR DESCRIPTION
When adding a scrollwheel footprint the WebUI is currently returning; `ReferenceError: standard is not defined`
(This works fine in the CLI on node 16.x)

I've added `const` in front of `standard` to make sure this gets defined as in other footprints