### PR TITLE
[CONCEPT] Add svgpath outline type

### DIFF
--- a/src/outlines.js
+++ b/src/outlines.js
@@ -234,7 +234,7 @@ exports.parse = (config = {}, points = {}, units = {}) => {
                 part = o.operation(part, {outline: Object.keys(outlines)})
             }
             const expected = ['type', 'operation']
-            part.type = a.in(part.type || 'outline', `${name}.type`, ['keys', 'rectangle', 'circle', 'polygon', 'outline'])
+            part.type = a.in(part.type || 'outline', `${name}.type`, ['keys', 'rectangle', 'circle', 'polygon', 'outline', 'svgpath'])
             part.operation = a.in(part.operation || 'add', `${name}.operation`, ['add', 'subtract', 'intersect', 'stack'])
 
             let op = u.union
@@ -312,6 +312,13 @@ exports.parse = (config = {}, points = {}, units = {}) => {
                     if (poly_mirror) {
                         arg = u.union(arg, u.poly(mirror_points))
                     }
+                    break
+                case 'svgpath':
+                    a.unexpected(part, name, expected.concat(['anchor', 'path']))
+                    const svgpath = a.sane(part.path, `${name}.path`, 'string')()
+                    anchor = anchor_lib.parse(anchor_def, `${name}.anchor`, points)()
+
+                    arg = m.importer.fromSVGPathData(svgpath);
                     break
                 case 'outline':
                     a.unexpected(part, name, expected.concat(['name', 'fillet']))


### PR DESCRIPTION
This PR adds a new `outline` type, `svgpath`
It takes SVG path data as input and outputs a MakerJS IModel using the [makerjs.importer.fromSVGPathData(pathData)](https://maker.js.org/docs/api/modules/makerjs.importer.html#fromsvgpathdata) function

We could also expose the `bezierAccuracy` setting to allow for bezier curve tweaking in the Ergogen config

I'm just opening the concept PR here so we can discuss implementation or follow-up steps.
Feel free to comment on the implementation or code-style

Ideally users may eventually want to import SVG files, however I think this would be a nice first step that enables current Ergogen users to use SVG paths and gain some more flexibility using outlines.
It currently takes a single path but converting existing SVGs to a single path is fairly trivial in most vector design software

An example of how this could be used;
```
outlines:
  exports:
    svgtest:
      - type: svgpath
        path: "M 95 35 L 59 35 L 48 0 L 36 35 L 0 35 L 29 56 L 18 90 L 48 69 L 77 90 L 66 56 Z"
        anchor:
          ref: matrix_ring_home
          shift: [-48, 50]
          rotate: 0
        mirror: true
 ```
 
 For a full working example you can clone my test branch and generate the PCB output
 `git clone https://github.com/MvEerd/shebang-keyboards.git`
 `git checkout svgtest`
 `npm install`
`npm run svgtest`

![image](https://user-images.githubusercontent.com/12560315/131988163-4fef1d2b-1f60-4753-b2f1-12fabc7e9421.png)
