### PR TITLE
Fix KLE import for WebUI

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
       myjscad = {}
     </script>
     <script src="js/openjscad.js"></script>
+    <script src="js/kle.js"></script>
     <script src="js/ergogen.js"></script>
     <script src="js/examples.js"></script>
     <script src="js/webui.js"></script>

--- a/js/kle.js
+++ b/js/kle.js
@@ -64,6 +64,14 @@ const Keyboard = /** @class */ (function () {
     return Keyboard;
 }());
 exports.Keyboard = Keyboard;
+const Serial = /** @class */ (function () {
+    function Serial() {
+        this.deserialize = null;
+        this.parse = null;
+    }
+    return Serial;
+}());
+exports.Serial = Serial;
 (function (exports) {
     // Helper to copy an object; doesn't handle loops/circular refs, etc.
     function copy(o) {
@@ -244,5 +252,5 @@ exports.Keyboard = Keyboard;
         }
         return kbd;
     }
-    exports.deserialize = deserialize;
+    exports.Serial.deserialize = deserialize;
 })(exports);


### PR DESCRIPTION
Currently the WebUI tries to use the function `kleSerial__default['default'].Serial.deserialize(config);`
However this is currently not being set due to `kle.js` not being included in index.html and due to the export being put directly in `global.kle.deserialize`

The following commits make it so KLE config works in the WebUI, without these change you'll get ```Error: Input doesn't resolve into an object!``` due to an exception while trying to call `deserialize`