### PR TITLE
(fix)outlines: Fillet all outline chains

### DIFF
--- a/src/outlines.js
+++ b/src/outlines.js
@@ -319,7 +319,14 @@ exports.parse = (config = {}, points = {}, units = {}) => {
                     const fillet = a.sane(part.fillet || 0, `${name}.fillet`, 'number')(units)
                     arg = u.deepcopy(outlines[part.name])
                     if (fillet) {
-                        arg.models.fillets = m.chain.fillet(m.model.findSingleChain(arg), fillet)
+                        const chains = m.model.findChains(arg);
+
+                        if (Array.isArray(chains)){
+                            chains.forEach((chain, i) => {
+                                arg.models[`fillet_${i}`] = m.chain.fillet(chain, fillet);
+                            });
+                        }
+
                     }
                     break
                 default:


### PR DESCRIPTION
As noted by @torik42 on Discord;

Currently when `fillet` is used on an outline it only fillets a single outline, whether this is created by two separate shapes or by mirroring.

I've traced this down to `findSingleChain` being used instead of `findChains` causing it to only find the first continous chain in the outline and ignore all others
I've implemented `findChains` in this PR, if you have any concerns about the implementation feel free to request any changes, thanks!

<details>
<summary>Example1 (columns)</summary>
<p>

```
points:
  key:
    padding: cy
    bind: 0.1
  zones:
    matrix:
      columns:
        one:
        two:
      rows:
        bottom:
        top:
outlines:
  exports:
    test_outline:
      - type: keys
        side: left
        size: cy
    fillet_outline:
      - type: outline
        name: test_outline
        fillet: 2
```

before:
![image](https://user-images.githubusercontent.com/12560315/132925160-1509fe0f-b508-453a-9894-8be1efa03db3.png)


after:
![image](https://user-images.githubusercontent.com/12560315/132925045-3c45ec9e-d35f-4023-8af4-eff0724781c1.png)



</p>
</details>  



<details>
<summary>Example2 (mirroring)</summary>
<p>

```
points:
  key:
    padding: cy
    bind: 2
  zones:
    matrix:
      columns:
        only:
      rows:
        bottom:
        top:
  mirror:
    ref: matrix_only_top
    distance: 30
outlines:
  glue:
    default:
      top:
        left:
          ref: mirror_matrix_only_top
          rotate: 12
        right:
          ref: matrix_only_top
          rotate: -12
      bottom:
        left:
          ref: mirror_matrix_only_bottom
          rotate: 12
        right:
          ref: matrix_only_bottom
          rotate: -12
  exports:
    rectangles:
      - type: rectangle
        anchor:
          ref: matrix_only_top
          shift: [-2,-2]
        size: [4,4]
        mirror: true
    test_outline:
      - type: keys
        side: both
        glue: default
        size: cy
      - type: outline
        name: rectangles
        fillet: 2
        operation: stack
```

before:
![image](https://user-images.githubusercontent.com/12560315/132925134-970cd3b4-67d0-43b5-8849-afed31d24d41.png)


after:
![image](https://user-images.githubusercontent.com/12560315/132925082-d156a5bb-c940-42d6-8bd9-a0b7f56ae158.png)


</p>
</details>  




