### PR TITLE
(fix, breaking current configs) properly mirror anchors

### DIFF
--- a/src/anchor.js
+++ b/src/anchor.js
@@ -45,17 +45,27 @@ const anchor = exports.parse = (raw, name, points={}, check_unexpected=true, def
         }
     }
     if (raw.orient !== undefined) {
-        point.r += a.sane(raw.orient, `${name}.orient`, 'number')(units)
+        let rval = a.sane(raw.orient, `${name}.orient`, 'number')(units)
+        if (mirror) {
+          point.r -= rval
+        } else {
+          point.r += rval
+        }
     }
     if (raw.shift !== undefined) {
         let xyval = a.wh(raw.shift, `${name}.shift`)(units)
-        if (point.meta.mirrored) {
+        if (mirror) {
             xyval[0] = -xyval[0]
         }
         point.shift(xyval, true)
     }
     if (raw.rotate !== undefined) {
-        point.r += a.sane(raw.rotate, `${name}.rotate`, 'number')(units)
+        let rval = a.sane(raw.rotate, `${name}.rotate`, 'number')(units)
+        if (mirror) {
+          point.r -= rval
+        } else {
+          point.r += rval
+        }
     }
     if (raw.affect !== undefined) {
         const candidate = point

--- a/src/pcbs.js
+++ b/src/pcbs.js
@@ -154,9 +154,10 @@ const footprint = exports._footprint = (config, name, points, point, net_indexer
     if (config === false) return ''
 
     // config sanitization
-    a.unexpected(config, name, ['type', 'anchor', 'nets', 'anchors', 'params'])
+    a.unexpected(config, name, ['type', 'anchor', 'nets', 'anchors', 'params', 'mirror_anchor'])
     const type = a.in(config.type, `${name}.type`, Object.keys(footprint_types))
-    let anchor = anchor_lib.parse(config.anchor || {}, `${name}.anchor`, points, true, point)(units)
+    const mirror_anchor = a.sane(config.mirror_anchor || true, `${name}.mirror_anchor`, 'boolean')()
+    let anchor = anchor_lib.parse(config.anchor || {}, `${name}.anchor`, points, true, point, mirror=(mirror_anchor && point && point.meta.mirrored))(units)
     const nets = a.sane(config.nets || {}, `${name}.nets`, 'object')()
     const anchors = a.sane(config.anchors || {}, `${name}.anchors`, 'object')()
     const params = a.sane(config.params || {}, `${name}.params`, 'object')()


### PR DESCRIPTION
This PR is a suggestion how to fix #33. It also fixes another issue with mirroring. But it will break certain configurations!

Issues this PR tries to fix:
1. Using primitive shapes with `mirror: true` and anchors that include `orient` or `rotate` entries does not result in a symmetric output.
2. Starting with a point named `mirrored_…`, any `shift` operation of an anchor is applied with negative x-shift. (I am not sure, whether this is considered as an issue. And this is also the point where probably many current configurations need adjustments)
3. There is quite strange behaviour when using `affect: xyr`, see #33.

For the first, one needs to change the direction of rotation for all mirrored objects (as is currently done for the x-shift). The rest is solved by using the `rotate` argument of the `anchor.parts` function to determine, whether these things should be inverted. This is also consistent, with the placement of rectangles (see example below). Currently, it is determined by `point.meta.mirrored` key, which is removed by specifying `affect: xyr` in the first (!) element of an anchor list.

Finally, here are some examples.
1. For comparison, here is the placement of rectangles (the small points mark the centres of the keys):
![mirror-rectangle](https://user-images.githubusercontent.com/77811180/132958852-b83b4b2e-31ab-4ade-a5f4-fe89fd754e15.png)
build with
    ```yaml
      - type: rectangle
        anchor:
          ref: matrix_only_top
        size: [5,5]
        mirror: true
        operation: stack
        
      - type: rectangle
        anchor:
          ref: mirror_matrix_only_middle
        size: [5,5]
        mirror: true
        operation: stack
        
      - type: rectangle
        anchor:
          ref: matrix_only_bottom
        size: [5,5]
        operation: stack
      - type: rectangle
        anchor:
          ref: mirror_matrix_only_bottom
        size: [5,5]
        operation: stack
    ```
    The schema will be the same for the following ones: the top is anchored on the left side and has a mirror, the middle is anchored on the right side and has a mirror. The bottom are two individual primitives (i.e. actually the same as the top left and the middle right).
2. Now a shift, again in the above variants:
    ```yaml
      - type: rectangle
        anchor:
          ref: (mirror_)matrix_only_…
          shift: [-4,-4]
        size: [5,5]
    ```
    The extra circle shows the “anchor” of the rectangle.
    The old variant: ![mirror-shift-rectangle](https://user-images.githubusercontent.com/77811180/132959060-d864b707-5ecf-4202-b430-bde2c2694302.png)
    The new variant: ![mirror-shift-rectangle](https://user-images.githubusercontent.com/77811180/132959077-a86f67a5-f298-49fa-863a-90b35ea8df07.png)

3. And finally something with a `orient`, again in the above variants:
    ```yaml
      - type: rectangle
        anchor:
          ref: (mirror_)matrix_only_…
          orient: 15
          shift: [-4,-4]
        size: [5,5]
    ```
    The old variant: ![mirror-orient](https://user-images.githubusercontent.com/77811180/132959152-87315f95-9c61-4d7c-8802-c19b1d2f2eb3.png)
    The new variant: ![mirror-orient](https://user-images.githubusercontent.com/77811180/132959171-acc436de-c936-466e-a561-7574582ed6b5.png)

Here is the [config](https://github.com/mrzealot/ergogen/files/7148396/raw.txt) for the above examples. For the `mirror-affect` example #35 is needed, or the `mirror: true` key must be removed.
