### PR TITLE
Tighten TRRS stab poles

### DIFF
--- a/src/footprints/trrs.js
+++ b/src/footprints/trrs.js
@@ -37,7 +37,7 @@ module.exports = {
       ${p.at /* parametric position */}   
 
       ${'' /* footprint reference */}
-      (fp_text reference REF** (at 0 14.2) (layer Dwgs.User) (effects (font (size 1 1) (thickness 0.15))))
+      (fp_text reference "${p.ref}" (at 0 14.2) (layer Dwgs.User) (effects (font (size 1 1) (thickness 0.15))))
       (fp_text value TRRS-PJ-320A-dual (at 0 -5.6) (layer F.Fab) (effects (font (size 1 1) (thickness 0.15))))
 
       ${''/* corner marks */}

--- a/src/footprints/trrs.js
+++ b/src/footprints/trrs.js
@@ -49,8 +49,8 @@ module.exports = {
       (fp_line (start 0.75 0) (end -5.35 0) (layer Dwgs.User) (width 0.15))
 
       ${''/* stabilizers */}
-      (pad "" np_thru_hole circle (at -2.3 8.6) (size 1.5 1.5) (drill 1.5) (layers *.Cu *.Mask))
-      (pad "" np_thru_hole circle (at -2.3 1.6) (size 1.5 1.5) (drill 1.5) (layers *.Cu *.Mask))
+      (pad "" np_thru_hole circle (at -2.3 8.6) (size 1.2 1.2) (drill 1.2) (layers *.Cu *.Mask))
+      (pad "" np_thru_hole circle (at -2.3 1.6) (size 1.2 1.2) (drill 1.2) (layers *.Cu *.Mask))
       `
     function pins(def_neg, def_pos) {
       return `

--- a/src/footprints/trrs.js
+++ b/src/footprints/trrs.js
@@ -1,14 +1,15 @@
 // TRRS-PJ-320A-dual
 //     _________________
-//    | (1)     (3) (4)|
+//    |   (2)   (3) (4)|
 //    |                |
-//    |___(2)__________|
+//    |_(1)____________|
 //
 // Nets
-//    A: corresponds to pin 1
-//    B: corresponds to pin 2
-//    C: corresponds to pin 3
-//    D: corresponds to pin 4
+//    A: corresponds to pin 1 (sleeve)
+//    B: corresponds to pin 2 (outer ring)
+//    C: corresponds to pin 3 (inner ring)
+//    D: corresponds to pin 4 (tip)
+//    Please note that this naming might not correspond to what is used in other boards; namely crkbd
 // Params
 //    reverse: default is false
 //      if true, will flip the footprint such that the pcb can be reversible

--- a/src/footprints/trrs.js
+++ b/src/footprints/trrs.js
@@ -69,8 +69,7 @@ module.exports = {
     } else if(p.param.reverse) {
         return `
           ${standard}
-          ${pins('-4.6', '0')}
-          ${pins('4.6', '0')})
+          ${pins('0', '-4.6')})
         `
       } else {
         return `


### PR DESCRIPTION
This PR tightens the TRRS footprint stabilizer holes to match those from Corne. What is currently 1.5mm becomes 1.2mm.
This still fits the device but allows much less wobble and easier soldering.
