### PR TITLE
Add key `individual` to zones allowing per point anchors

### DIFF
--- a/test/points/individual.yaml
+++ b/test/points/individual.yaml
@@ -1,0 +1,18 @@
+points:
+  zones:
+    matrix:
+      columns:
+        left:
+        right:
+      rows:
+        bottom:
+        top:
+    extra:
+      rotate: 5
+      anchor:
+        ref: matrix_right_top
+      individual:
+        first:
+          anchor:
+            ref: matrix_right_top
+            shift: [8,8]

--- a/test/points/individual___points.json
+++ b/test/points/individual___points.json
@@ -1,0 +1,170 @@
+{
+    "matrix_left_bottom": {
+        "x": 0,
+        "y": 0,
+        "r": 0,
+        "meta": {
+            "shift": [
+                0,
+                0
+            ],
+            "rotate": 0,
+            "padding": 19,
+            "width": 1,
+            "height": 1,
+            "skip": false,
+            "asym": "both",
+            "name": "matrix_left_bottom",
+            "colrow": "left_bottom",
+            "col": {
+                "stagger": 0,
+                "spread": 0,
+                "rotate": 0,
+                "origin": [
+                    0,
+                    0
+                ],
+                "rows": {},
+                "key": {},
+                "name": "left"
+            },
+            "row": "bottom"
+        }
+    },
+    "matrix_left_top": {
+        "x": 0,
+        "y": 19,
+        "r": 0,
+        "meta": {
+            "shift": [
+                0,
+                0
+            ],
+            "rotate": 0,
+            "padding": 19,
+            "width": 1,
+            "height": 1,
+            "skip": false,
+            "asym": "both",
+            "name": "matrix_left_top",
+            "colrow": "left_top",
+            "col": {
+                "stagger": 0,
+                "spread": 0,
+                "rotate": 0,
+                "origin": [
+                    0,
+                    0
+                ],
+                "rows": {},
+                "key": {},
+                "name": "left"
+            },
+            "row": "top"
+        }
+    },
+    "matrix_right_bottom": {
+        "x": 19,
+        "y": 0,
+        "r": 0,
+        "meta": {
+            "shift": [
+                0,
+                0
+            ],
+            "rotate": 0,
+            "padding": 19,
+            "width": 1,
+            "height": 1,
+            "skip": false,
+            "asym": "both",
+            "name": "matrix_right_bottom",
+            "colrow": "right_bottom",
+            "col": {
+                "stagger": 0,
+                "spread": 19,
+                "rotate": 0,
+                "origin": [
+                    0,
+                    0
+                ],
+                "rows": {},
+                "key": {},
+                "name": "right"
+            },
+            "row": "bottom"
+        }
+    },
+    "matrix_right_top": {
+        "x": 19,
+        "y": 19,
+        "r": 0,
+        "meta": {
+            "shift": [
+                0,
+                0
+            ],
+            "rotate": 0,
+            "padding": 19,
+            "width": 1,
+            "height": 1,
+            "skip": false,
+            "asym": "both",
+            "name": "matrix_right_top",
+            "colrow": "right_top",
+            "col": {
+                "stagger": 0,
+                "spread": 19,
+                "rotate": 0,
+                "origin": [
+                    0,
+                    0
+                ],
+                "rows": {},
+                "key": {},
+                "name": "right"
+            },
+            "row": "top"
+        }
+    },
+    "extra__first": {
+        "x": 27,
+        "y": 27,
+        "r": 0,
+        "meta": {
+            "shift": [
+                0,
+                0
+            ],
+            "rotate": 0,
+            "padding": 19,
+            "width": 1,
+            "height": 1,
+            "skip": false,
+            "asym": "both",
+            "anchor": {
+                "ref": "matrix_right_top",
+                "shift": [
+                    8,
+                    8
+                ]
+            },
+            "name": "extra__first",
+            "colrow": "_first",
+            "col": {
+                "stagger": 0,
+                "spread": 0,
+                "rotate": 0,
+                "origin": [
+                    0,
+                    0
+                ],
+                "rows": {},
+                "key": {},
+                "name": ""
+            },
+            "row": "first",
+            "individual": true
+        }
+    }
+}


### PR DESCRIPTION
This PR allows for zones, in which individual points with per-point anchors are specified. Since the points from the zone itself wouldn’t be available anyway, I see no necessity for per-point anchors in usual col-row-zones.

Details:
- add key `individual` to zones, exclusive with `rows` and `columns`
- under `individual` one specifies single points with individual anchors
- per zone rotations are not applied to these points
- add test

Explanation of implementation: To avoid duplicate code, I actually create a usual zone with one column named `''` and a row for each key. Thus, the points gets names like `zone__key` which clearly distinguishes them from usual col-row-keys. If no per-point anchor is given, the zone-anchor is used. Any present per-zone rotation is not applied, because it would render the anchors useless.

If you come up with a better name, feel free to change or tell me.