### PR TITLE
Allow custom footprints to be passed in via cli

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -16,6 +16,11 @@ const args = yargs
         describe: 'Output folder',
         type: 'string'
     })
+    .option('footprints', {
+        alias: 'f',
+        describe: 'Additional footprints folder',
+        type: 'string',
+    })
     .option('debug', {
         alias: 'd',
         default: false,
@@ -48,6 +53,28 @@ try {
 const title_suffix = args.debug ? ' (Debug Mode)' : ''
 console.log(`Ergogen v${pkg.version} CLI${title_suffix}`)
 console.log()
+
+// load additional footprints
+
+if (args.footprints) {
+    const dirFiles = fs.readdirSync(path.resolve(args.footprints))
+
+    for (let index = 0; index < dirFiles.length; index++) {
+        const file = dirFiles[index];
+        if (file.endsWith('.js')) {
+            const name = path.basename(file, '.js')
+            const footprint = require(path.resolve(args.footprints, file))
+            if (
+                typeof footprint === 'object' &&
+                typeof footprint.nets === 'object' &&
+                typeof footprint.params === 'object' &&
+                typeof footprint.body === 'function'
+            ) {
+                ergogen.inject_footprint(name, footprint)
+            }
+        }
+    }
+}
 
 ;(async () => {
 


### PR DESCRIPTION
Many people fork ergogen in order to add custom footprints. This is a little cumbersome and since there is already a way to inject footprints at runtime I have exposed this feature. 

Please let me know if there are any other improvements you would like me to make before merging, as I do realize my implementation is a little naive (though my position is the CLI is a power user feature, and custom footprints double so. I saw it as "use at your own risk" sort of thing. 

Example of use: 

```
./src/cli.js test.yaml -o ./out -f ./footprints --clean
```  

This allows, for example, a user to load a reversible promicro footprint, or any other custom footprint they wish. Users can depend on `ergodash` in their package.json for their project, then load footprints from their repo with out any need to fork (if all they wish is to load custom footprints)

