### PR TITLE
Prevent duplicate net names between the main board and its mirror

### DIFF
--- a/src/pcbs.js
+++ b/src/pcbs.js
@@ -202,6 +202,10 @@ const footprint = exports._footprint = (config, name, points, point, net_indexer
             net = point.meta[indirect]
             net = a.sane(net, `${name}.nets.${net_name} --> ${point.meta.name}.${indirect}`, 'string')()
         }
+        // Prevent duplicate net names between the main board and its mirror
+        if (point.meta.name.startsWith("mirror_")) {
+            net = `mirror_${net}`
+        }
         const index = net_indexer(net)
         parsed_params.net[net_name] = {
             name: net,


### PR DESCRIPTION
I faced the problem when making a mirrored board that the net names were the same, causing a mess of links between the two parts of the keyboard.
![mess of links between two parts of the keyboard](https://i.ibb.co/RTrzrz2/Screenshot-20220808-123558.png)
I added a simple rule so that all the points being part of a mirrored pcb (in other words, the points having a name starting with `mirror_`) got `mirror_` added at the start of their net names too.
Result:
![after the fix](https://i.ibb.co/wyTzVHk/Screenshot-20220808-124206.png)
Consequences:
The net names on the mirrored part of the board start with `mirror_`, which should be avoided if possible. (If changing only the ID, kicad complains about the name of the nets not corresponding to their IDs...)
Note: I'm not sure if this fix will work on other footprints like microcontrollers, but I think it would (because it changes the name of the nets regardless of the type of footprint).