### PR TITLE
Improved diode footprint with connection between pads and THT terminals

### DIFF
--- a/src/footprints/diode.js
+++ b/src/footprints/diode.js
@@ -34,15 +34,20 @@ module.exports = {
         (fp_line (start -0.75 0) (end -0.35 0) (layer B.SilkS) (width 0.1))
     
         ${''/* SMD pads on both sides */}
-        (pad 1 smd rect (at -1.65 0 ${p.rot}) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) ${p.net.to.str})
-        (pad 2 smd rect (at 1.65 0 ${p.rot}) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) ${p.net.from.str})
-        (pad 1 smd rect (at -1.65 0 ${p.rot}) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) ${p.net.to.str})
-        (pad 2 smd rect (at 1.65 0 ${p.rot}) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) ${p.net.from.str})
-        
+        (pad 1 smd rect (at -1.65 0 ${p.rot}) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask))
+        (pad 2 smd rect (at 1.65 0 ${p.rot}) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask))
+        (pad 1 smd rect (at -1.65 0 ${p.rot}) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask))
+        (pad 2 smd rect (at 1.65 0 ${p.rot}) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask))
+
         ${''/* THT terminals */}
-        (pad 1 thru_hole circle (at 3.81 0 ${p.rot}) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) ${p.net.from.str})
-        (pad 2 thru_hole rect (at -3.81 0 ${p.rot}) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) ${p.net.to.str})
+        (pad 1 thru_hole rect (at -3.81 0 ${p.rot}) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) ${p.net.to.str})
+        (pad 2 thru_hole circle (at 3.81 0 ${p.rot}) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) ${p.net.from.str})
+
+        ${''/* connect THT and pads */}
+        (fp_line (start 3.81 0) (end 2.1 0) (layer F.Cu) (width 0.25))
+        (fp_line (start 3.81 0) (end 2.1 0) (layer B.Cu) (width 0.25))
+        (fp_line (start -3.81 0) (end -2.1 0) (layer F.Cu) (width 0.25))
+        (fp_line (start -3.81 0) (end -2.1 0) (layer B.Cu) (width 0.25))
     )
-  
     `
 }


### PR DESCRIPTION
4 connections less to make manually per key. With 36 keys, that is already more than 100 connections less to make manually.

![image](https://user-images.githubusercontent.com/13719903/186770392-c60a8af0-4623-44e8-bde5-fa142662b671.png)

Also switches numbers between the THT terminals so THT 1 is on the side of pad 1.
