### PR TITLE
fix: use all but last character as `expand` value in `expand_shorthand`

### DIFF
--- a/src/outlines.js
+++ b/src/outlines.js
@@ -140,7 +140,7 @@ const expand_shorthand = (config, units) => {
     if (a.type(config.expand)(units) == 'string') {
         const prefix = config.expand.slice(0, -1)
         const suffix = config.expand.slice(-1)
-        let expand = suffix
+        let expand = prefix
         let joints = 0
         
         if (suffix == ')') ; // noop


### PR DESCRIPTION
Fixes (what I'm guessing is) a typo. My interpretation of the intended format is `123]`, `456)` and similar, all of which now seem to work.

Found while trying to write tests in #77 