### PR TITLE
Add Nice!View footprint

### DIFF
--- a/src/footprints/index.js
+++ b/src/footprints/index.js
@@ -17,4 +17,5 @@ module.exports = {
     slider: require('./slider'),
     trrs: require('./trrs'),
     via: require('./via'),
+    niceview: require('./niceview'),
 }

--- a/src/footprints/niceview.js
+++ b/src/footprints/niceview.js
@@ -1,0 +1,32 @@
+module.exports = {
+    params: {
+        designator: 'Nice!View',
+        side: 'F',
+        VCC: { type: 'net', value: 'VCC' },
+        GND: { type: 'net', value: 'GND' },
+        SDA: undefined,
+        SCL: undefined,
+        CS: undefined,
+    },
+    body: p => `
+        (module lib:niceview_headers (layer F.Cu) (tedit 648E0265)
+        ${p.at /* parametric position */} 
+
+        ${'' /* footprint reference */}        
+        (fp_text reference "${p.ref}" (at -1.6 0) (layer F.SilkS) ${p.ref_hide} (effects (font (size 1.27 1.27) (thickness 0.15))))
+        (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1 1) (thickness 0.15))))
+
+        ${'' /* pins */}
+        (pad 4 thru_hole oval (at 0.0 -5.08 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+        ${p.SDA.str})
+        (pad 3 thru_hole oval (at 0.0 -2.54 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+        ${p.SCL.str})
+        (pad 2 thru_hole oval (at 0.0  0.00 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+        ${p.VCC.str})
+        (pad 1 thru_hole rect (at 0.0  2.54 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+        ${p.GND.str})
+        (pad 1 thru_hole oval (at 0.0  5.08 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+        ${p.CS.str})
+        )
+        `
+}

--- a/src/footprints/niceview.js
+++ b/src/footprints/niceview.js
@@ -2,31 +2,51 @@ module.exports = {
     params: {
         designator: 'Nice!View',
         side: 'F',
+        outline: false,
         VCC: { type: 'net', value: 'VCC' },
         GND: { type: 'net', value: 'GND' },
         SDA: undefined,
         SCL: undefined,
         CS: undefined,
     },
-    body: p => `
-        (module lib:niceview_headers (layer F.Cu) (tedit 648E0265)
-        ${p.at /* parametric position */} 
+    body: p => {
+        const standard = `
+            (module lib:niceview_headers (layer F.Cu) (tedit 648E0265)
+            ${p.at /* parametric position */} 
 
-        ${'' /* footprint reference */}        
-        (fp_text reference "${p.ref}" (at -1.6 0) (layer F.SilkS) ${p.ref_hide} (effects (font (size 1.27 1.27) (thickness 0.15))))
-        (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1 1) (thickness 0.15))))
+            ${'' /* footprint reference */}        
+            (fp_text reference "${p.ref}" (at -1.6 0) (layer F.SilkS) ${p.ref_hide} (effects (font (size 1.27 1.27) (thickness 0.15))))
+            (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1 1) (thickness 0.15))))
 
-        ${'' /* pins */}
-        (pad 4 thru_hole oval (at 0.0 -5.08 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
-        ${p.SDA.str})
-        (pad 3 thru_hole oval (at 0.0 -2.54 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
-        ${p.SCL.str})
-        (pad 2 thru_hole oval (at 0.0  0.00 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
-        ${p.VCC.str})
-        (pad 1 thru_hole rect (at 0.0  2.54 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
-        ${p.GND.str})
-        (pad 1 thru_hole oval (at 0.0  5.08 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
-        ${p.CS.str})
-        )
+            ${'' /* pins */}
+            (pad 4 thru_hole oval (at 0.0 -5.08 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+            ${p.SDA.str})
+            (pad 3 thru_hole oval (at 0.0 -2.54 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+            ${p.SCL.str})
+            (pad 2 thru_hole oval (at 0.0  0.00 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+            ${p.VCC.str})
+            (pad 1 thru_hole rect (at 0.0  2.54 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+            ${p.GND.str})
+            (pad 1 thru_hole oval (at 0.0  5.08 ${p.rot + 270}) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask)
+            ${p.CS.str})
         `
+        function outline() {
+            return `
+              ${'' /* Nice!View outline */}
+              (fp_line (start -1.25 -7) (end -1.25 7) (layer F.SilkS) (width 0.15))
+              (fp_line (start -1.25 7) (end 34.75 7) (layer F.SilkS) (width 0.15))
+              (fp_line (start 34.75 7) (end 34.75 -7) (layer F.SilkS) (width 0.15))
+              (fp_line (start 34.75 -7) (end -1.25 -7) (layer F.SilkS) (width 0.15))
+              `
+        }
+        if (p.outline) {
+            return `
+              ${standard}
+              ${outline()})
+              `
+        } else {
+            return `${standard})`
+        }
+    }
+
 }


### PR DESCRIPTION
Adds the footprint of the popular Nice!View eInk display. It is very similar to a standard oled, but features an additional pin, so it is based on the `oled.js`. I made some additional changes to center the footprint on the central pin and allow to draw an outline.

![image](https://github.com/ergogen/ergogen/assets/4690162/33705a9a-89d8-4fb3-930f-25a350604ee5)
