### PR TITLE
Added intersect aggregator

### DIFF
--- a/src/anchor.js
+++ b/src/anchor.js
@@ -61,7 +61,7 @@ const aggregators = {
 
         const intersection_point_arr = intersection.intersectionPoints[0]
         const intersection_point = new Point(
-            intersection_point_arr[0], intersection_point_arr[1], parts[1].r
+            intersection_point_arr[0], intersection_point_arr[1]
         )
 
         return intersection_point

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -31,12 +31,19 @@ const aggregators = {
         return new Point(x / len, y / len, r / len)
     },
     intersect: (config, name, parts) => {
+        // a line is generated from a point by taking their
+        // (rotated) Y axis. The line is not extended to
+        // +/- Infinity as that doesn't work with makerjs.
+        // An arbitrary offset of 1 meter is considered
+        // sufficient for practical purposes, and the point
+        // coordinates are used as pivot point for the rotation.
         const get_line_from_point = (point, offset=1000) => {
-            const p1 = [point.x, point.y]
+            const origin = [point.x, point.y]
+            const p1 = [point.x, point.y - offset]
             const p2 = [point.x, point.y + offset]
 
             let line = new m.paths.Line(p1, p2)
-            line = m.path.rotate(line, point.r, p1)
+            line = m.path.rotate(line, point.r, origin)
 
             return line
         }

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -42,6 +42,7 @@ const aggregators = {
         }
 
         a.unexpected(config, name, aggregator_common)
+        a.assert(parts.length==2, `Intersect expects exactly two parts, but it got ` + parts.length + `!`)
 
         const line1 = get_line_from_point(parts[0])
         const line2 = get_line_from_point(parts[1])

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -31,37 +31,27 @@ const aggregators = {
         return new Point(x / len, y / len, r / len)
     },
     intersect: (config, name, parts) => {
-        const get_line_from_point = (point, axis, offset=1000) => {
-            let p1 = [point.x - offset, point.y]
-            let p2 = [point.x + offset, point.y]
-            if(axis == 'y') {
-                p1 = [point.x, point.y - offset]
-                p2 = [point.x, point.y + offset]
-            }
+        const get_line_from_point = (point, offset=1000) => {
+            const p1 = [point.x, point.y]
+            const p2 = [point.x, point.y + offset]
 
             let line = new m.paths.Line(p1, p2)
-            line = m.path.rotate(line, point.r, point.p)
+            line = m.path.rotate(line, point.r, p1)
 
             return line
         }
 
-        a.unexpected(
-            config, name,
-            [...aggregator_common, ...['axis1', 'axis2']]
-        )
-        a.in(config.axis1, 'axis1', ['x', 'y'])
-        a.in(config.axis2, 'axis2', ['x', 'y'])
-        a.arr(parts, `${name}.parts`, 2, 'Point', '')
+        a.unexpected(config, name, aggregator_common)
 
-        const line1 = get_line_from_point(parts[0], config.axis1)
-        const line2 = get_line_from_point(parts[1], config.axis2)
+        const line1 = get_line_from_point(parts[0])
+        const line2 = get_line_from_point(parts[1])
         const intersection = m.path.intersection(line1, line2)
 
         a.assert(intersection, `The points under "${name}.parts" do not intersect!`)
 
         const intersection_point_arr = intersection.intersectionPoints[0]
         const intersection_point = new Point(
-            intersection_point_arr[0], intersection_point_arr[1]
+            intersection_point_arr[0], intersection_point_arr[1], 0
         )
 
         return intersection_point

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -43,7 +43,7 @@ const aggregators = {
             line = m.path.rotate(line, point.r, point.p)
 
             return line
-        };
+        }
 
         a.unexpected(
             config, name,
@@ -51,13 +51,13 @@ const aggregators = {
         )
         a.in(config.axis1, 'axis1', ['x', 'y'])
         a.in(config.axis2, 'axis2', ['x', 'y'])
-        a.arr(parts, 'parts', 2, 'Point')
+        a.arr(parts, `${name}.parts`, 2, 'Point', '')
 
         const line1 = get_line_from_point(parts[0], config.axis1)
         const line2 = get_line_from_point(parts[1], config.axis2)
-        var intersection = m.path.intersection(line1, line2);
+        const intersection = m.path.intersection(line1, line2)
 
-        a.assert(intersection != null, `There is no intersection for ${name}`)
+        a.assert(intersection, `The points under "${name}.parts" do not intersect!`)
 
         const intersection_point_arr = intersection.intersectionPoints[0]
         const intersection_point = new Point(

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -61,7 +61,7 @@ const aggregators = {
 
         const intersection_point_arr = intersection.intersectionPoints[0]
         const intersection_point = new Point(
-            intersection_point_arr[0], intersection_point_arr[1]
+            intersection_point_arr[0], intersection_point_arr[1], parts[1].r
         )
 
         return intersection_point

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -42,7 +42,7 @@ const aggregators = {
         }
 
         a.unexpected(config, name, aggregator_common)
-        a.assert(parts.length==2, `Intersect expects exactly two parts, but it got ` + parts.length + `!`)
+        a.assert(parts.length==2, `Intersect expects exactly two parts, but it got ${parts.length}!`)
 
         const line1 = get_line_from_point(parts[0])
         const line2 = get_line_from_point(parts[1])

--- a/test/unit/anchor.js
+++ b/test/unit/anchor.js
@@ -75,7 +75,7 @@ describe('Anchor', function() {
           ref : 'ten'
         }, 'name', points).should.throw()
     })
-    it('aggregate_intersect', function() {
+    it('intersect', function() {
         // points are facing (i.e. their rotated Y axis) in non-intersecting directions
         parse({
             aggregate: {

--- a/test/unit/anchor.js
+++ b/test/unit/anchor.js
@@ -6,6 +6,9 @@ describe('Anchor', function() {
 
     const points = {
         o: new Point(0, 0, 0, {label: 'o'}),
+        rotated_o: new Point(0, 0, 90, {label: 'rotated_o'}),
+        o_five: new Point(0, 5, 0, {label: 'o_five'}),
+        five: new Point(5, 5, 90, {label: 'five'}),
         ten: new Point(10, 10, -90, {label: 'ten'}),
         mirror_ten: new Point(-10, 10, 90, {mirrored: true})
     }
@@ -71,6 +74,69 @@ describe('Anchor', function() {
           },
           ref : 'ten'
         }, 'name', points).should.throw()
+    })
+    it('aggregate_intersect', function() {
+        // points are facing (i.e. their rotated Y axis) in non-intersecting directions
+        parse({
+            aggregate: {
+                parts: ['o','ten'],
+                method: 'intersect'
+            }
+        }, 'name', points).should.throw(`The points under "name.aggregate.parts" do not intersect!`)
+
+        // points intersect
+        check(
+            parse({
+                aggregate: {
+                    parts: ['o','five'],
+                    method: 'intersect'
+                }
+            }, 'name', points)(),
+            [0, 5, 0, {}]
+        )
+
+        // intersecting points with the same coordinates, but different rotations
+        check(
+            parse({
+                aggregate: {
+                    parts: ['o','rotated_o'],
+                    method: 'intersect'
+                }
+            }, 'name', points)(),
+            [0, 0, 0, {}]
+        )
+        
+        // points with overlapping directions
+        parse({
+            aggregate: {
+                parts: ['o','o_five'],
+                method: 'intersect'
+            }
+        }, 'name', points).should.throw(`The points under "name.aggregate.parts" do not intersect!`)
+
+        // more than two parts
+        parse({
+            aggregate: {
+                parts: ['o', `five`, `ten`],
+                method: 'intersect'
+            }
+        }, 'name', points).should.throw(`Intersect expects exactly two parts, but it got 3!`)
+
+        // only one part
+        parse({
+            aggregate: {
+                parts: ['o'],
+                method: 'intersect'
+            }
+        }, 'name', points).should.throw(`Intersect expects exactly two parts, but it got 1!`)
+
+        // no parts
+        parse({
+            aggregate: {
+                method: 'intersect'
+            }
+        }, 'name', points).should.throw(`Intersect expects exactly two parts, but it got 0!`)
+
     })
 
     it('shift', function() {

--- a/test/unit/anchor.js
+++ b/test/unit/anchor.js
@@ -8,6 +8,7 @@ describe('Anchor', function() {
         o: new Point(0, 0, 0, {label: 'o'}),
         rotated_o: new Point(0, 0, 90, {label: 'rotated_o'}),
         o_five: new Point(0, 5, 0, {label: 'o_five'}),
+        five_o: new Point(5, 0, 0, {label: 'five_o'}),
         five: new Point(5, 5, 90, {label: 'five'}),
         ten: new Point(10, 10, -90, {label: 'ten'}),
         mirror_ten: new Point(-10, 10, 90, {mirrored: true})
@@ -76,15 +77,26 @@ describe('Anchor', function() {
         }, 'name', points).should.throw()
     })
     it('intersect', function() {
-        // points are facing (i.e. their rotated Y axis) in non-intersecting directions
+        // points that intersect on a negative Y axis
+        check(
+            parse({
+                aggregate: {
+                    parts: ['o','ten'],
+                    method: 'intersect'
+                }
+            }, 'name', points)(),
+            [0,10,0,{}]
+        )
+
+        // points that have parallel Y axis, i.e. never intersect
         parse({
             aggregate: {
-                parts: ['o','ten'],
+                parts: ['o','five_o'],
                 method: 'intersect'
             }
         }, 'name', points).should.throw(`The points under "name.aggregate.parts" do not intersect!`)
 
-        // points intersect
+        // points intersect on their positive Y axis
         check(
             parse({
                 aggregate: {
@@ -106,7 +118,7 @@ describe('Anchor', function() {
             [0, 0, 0, {}]
         )
         
-        // points with overlapping directions
+        // points with overlapping Y axis
         parse({
             aggregate: {
                 parts: ['o','o_five'],
@@ -136,7 +148,6 @@ describe('Anchor', function() {
                 method: 'intersect'
             }
         }, 'name', points).should.throw(`Intersect expects exactly two parts, but it got 0!`)
-
     })
 
     it('shift', function() {


### PR DESCRIPTION
Hi guys,

this PR adds a new aggregation method, `intersect`. This allows you to find a point where two lines intersect.

Here is an example...

```yaml
points:
  zones:
    [...]
    edge_thumb_cluster_bottom:
      anchor:
        ref:
          aggregate:
            method: intersect
            parts:
              - edge_thumb_cluster_bottom_tmp
              - edge_thumb_cluster_top_splayed
            axis1: x
            axis2: y
      key:
        name: edge_thumb_cluster_bottom
```

Which creates the following point...
<img width="948" alt="Intersection Point" src="https://github.com/ergogen/ergogen/assets/7404004/607d473b-ea8d-462c-8b1d-476dbdbe0cd0">

You might have noticed that the config above only supplied two references/points, but in order to intersect two lines, you need two points for each line (four in total).

This is because the method creates "virtual" lines using the references' coordinates, rotation and the supplied axes.

This way you can just use two points and don't need to create additional points.

# How to test this

## Install the ergogen fork for this PR
```shell
git clone https://github.com/infused-kim/ergogen.git
cd ergogen
git checkout dev/aggregator_intersect

# Install ergogen and dependencies
npm i -g ergogen 

# Remove just the ergogen package
npm rm -g ergogen

# Install forked ergogen package
npm install -g ./
```

## Use the following test config
Add the following config into a directory and name it `config.yaml`.

The meat of how to use this is in the `points` section below
```yaml
    #
    # Helper Points
    #
```

The full config...
```yaml
units:
  # Key Spacing
  # cx and cy are ergogen's choc spacing units.
  kx: cx
  ky: cy
  kxo: 0.5 * kx
  kyo: 0.5 * ky
  px: kx + 2
  py: ky + 2

  # Stagger
  stagger_outer: 0
  stagger_pinky: 0
  stagger_ring: 4.75
  stagger_middle: 2.375
  stagger_index: -2.375
  stagger_inner: -2.375

  # Thumb key splay
  splay_outer: 0
  splay_pinky: 0
  splay_ring: 0
  splay_middle: 0
  splay_index: 0
  splay_inner: 0
  splay_thumb_home: -15
  splay_thumb_inner: -15
  splay_thumb_inner_extra: 90

  # PCB Edge Padding
  pcb_outline_padding_top: 0.1
  pcb_outline_padding_bottom: 0.1
  pcb_outline_padding_left: 0
  pcb_outline_padding_right: 0

  # Inner thumb settings
  thumb_inner_width: 1.5
  edge_thumb_cluster_top_shift_x: thumb_inner_width * 0.5 * kx
  edge_thumb_cluster_top_shift_y: -0.5 * ky
  edge_thumb_cluster_bottom_shift_x: -0.5 * kx * thumb_inner_width - pcb_outline_padding_top
  edge_thumb_cluster_bottom_shift_y: 0

  # Keycap Size
  # Ergogen's automatically adds 0.5mm to the cx and cy units
  # to add spacing between the keys.
  # The numbers below are the actual keycap sizes that will be displayed
  # in the pcb to check proper alignment and spacing
  keycaps_x: 17.5
  keycaps_y: 16.5
  keycaps_thumb_inner_x: 26.5
  keycaps_thumb_inner_y: 16.5
  keycaps_thumb_inner_xo: 0.5 * keycaps_thumb_inner_x
  keycaps_thumb_inner_yo: 0.5 * keycaps_thumb_inner_y

  # Thumb Cluster offset from bottom index finger key
  thumb_cluster_offset_x: -8.5
  thumb_cluster_offset_y: -19.625

  # Thumb Cluster Offsets
  thumb_home_move_x: 2
  thumb_home_move_y: -2.7
  thumb_inner_move_x: 2.7
  thumb_inner_move_y: 2.3

  # Font units
  font_x: 1
  font_y: 1
  font_xo: 0.5 font_x
  font_yo: 0.5 * font_y

  # Nice Nano
  # The nice nano footprint's center doesn't account
  mcu_spacing_left: 1.25
  mcu_spacing_right: 1.5
  mcu_x: 17.78
  mcu_y: 33.0
  mcu_xo: 0.5 * mcu_x
  mcu_yo: 0.5 * mcu_y

points:
  zones:

    #
    # Main Key Matrix
    #
    matrix:

      # Fix placement on KiCAD sheet.
      anchor:
        shift: [100, -100]

      key:
        padding: 1ky
        spread: 1kx
        tags: key

      columns:
        outer:
          key:
            stagger: stagger_outer
            splay: splay_outer
            column_net: C0
        pinky:
          key:
            stagger: stagger_pinky
            splay: splay_pinky
            column_net: C1
        ring:
          key:
            stagger: stagger_ring
            splay: splay_ring
            column_net: C2
        middle:
          key:
            stagger: stagger_middle
            splay: splay_middle
            column_net: C3
        index:
          key:
            stagger: stagger_index
            splay: splay_index
            column_net: C4
        inner:
          key:
            stagger: stagger_inner
            splay: splay_inner
            column_net: C5

      rows:
        bottom:
          row_net: R3
        home:
          row_net: R2
        top:
          row_net: R1

    #
    # Thumb Cluster
    #
    thumbs:
      key:
        padding: 1ky
        spread: 1kx
        tags: key
      anchor:
        ref: matrix_index_bottom
        shift: [thumb_cluster_offset_x, thumb_cluster_offset_y]
      columns:
        outer:
            key:
              column_net: C3
        home:
            key:
              splay: splay_thumb_home
              spread: 1kx + thumb_home_move_x
              stagger: thumb_home_move_y
              column_net: C4
        inner:
            key:
              width: kx * thumb_inner_width
              splay: splay_thumb_inner + splay_thumb_inner_extra
              spread: 1kx + thumb_inner_move_x
              stagger: thumb_inner_move_y
              tags: key_thumb_inner
              column_net: C5
      rows:
        # Thumbs only have one row.
        cluster:
          row_net: R4

    #
    #  Controller
    #
    controller:
      anchor:
        ref: matrix_inner_top
        shift: [kxo + mcu_xo + mcu_spacing_left, kyo - mcu_yo + pcb_outline_padding_top]
      key:
        name: mcu
        width: mcu_x
        height: mcu_y

    #
    # Helper Points
    #
    edge_mcu_top_right:
      anchor:
        ref: mcu
        shift: [+mcu_xo + mcu_spacing_right + pcb_outline_padding_right, +mcu_yo]

    edge_thumb_cluster_top_splayed:
      anchor:
        - ref: thumbs_inner_cluster
          shift: [edge_thumb_cluster_top_shift_x, edge_thumb_cluster_top_shift_y]
        - ref: edge_mcu_top_right
          affect: x
      key:
        name: edge_thumb_cluster_top_splayed
        # If the inner thumb is 1.5u and rotated by 90 degrees,
        # remove that rotation
        splay: -splay_thumb_inner_extra


    edge_thumb_cluster_top:
      anchor:
        - ref: edge_thumb_cluster_top_splayed
      key:
        name: edge_thumb_cluster_top
         # thumbs_inner_cluster is splayed. So here we "unsplay" it
         # to make the edge straight for placement of other components
         # along the right side outline.
        splay: -splay_thumb_home - splay_thumb_inner

    edge_thumb_cluster_bottom_tmp:
      anchor:
        ref: thumbs_inner_cluster
        shift: [edge_thumb_cluster_bottom_shift_x, edge_thumb_cluster_bottom_shift_y]
      key:
        name: edge_thumb_cluster_bottom_tmp
        # If the inner thumb is 1.5u and rotated by 90 degrees,
        # remove that rotation
        splay: -splay_thumb_inner_extra

    edge_thumb_cluster_bottom:
      anchor:
        ref:
          aggregate:
            method: intersect
            parts:
              - edge_thumb_cluster_bottom_tmp
              - edge_thumb_cluster_top_splayed
            axis1: x
            axis2: y
      key:
        name: edge_thumb_cluster_bottom

pcbs:
  intersect_test:
    outlines:
      main:
        outline: board
    footprints:

      # Key Area
      # Regular keys with hotswap
      choc_hotswap:
        what: choc
        where: [key]
        params:
          reverse: true
          hotswap: true
          from: "{{column_net}}"
          to: "{{colrow}}"
        adjust:
          shift: [0,0]
          rotate: -180

      # 1.5u thumb key
      choc_hotswap_thumb_inner:
        what: choc
        where: [key_thumb_inner]
        params:
          reverse: true
          hotswap: true
          keycaps: true
          from: "{{column_net}}"
          to: "{{colrow}}"
        adjust:
          shift: [0,0]
          rotate: -180

      diode:
        what: diode
        where: [key, key_thumb_inner]
        params:
          from: "{{colrow}}"
          to: "{{row_net}}"
        adjust:
          shift: [0, 3.8]


outlines:

  # Pure key outline.
  raw:
    - what: rectangle
      where: true
      size: [px, py]

  # Key outlines with 0.5mm removed to show key overlaps.
  keys:
    - what: rectangle
      where: true
      size: [kx-0.5,ky-0.5]

  # Actual outline of the board
  board:
    - what: polygon
      operation: stack
      fillet: 0.5
      points:

        # Top
        # Outer
        - ref: matrix_outer_top
          shift: [-kxo - pcb_outline_padding_left, +kyo + pcb_outline_padding_top]
        - ref: matrix_outer_top
          shift: [+kxo, +kyo + pcb_outline_padding_top]

        # Pinky
        - ref: matrix_pinky_top
          shift: [-kxo, +kyo + pcb_outline_padding_top]
        - ref: matrix_pinky_top
          shift: [+kxo, +kyo + pcb_outline_padding_top]

        # Ring
        - ref: matrix_ring_top
          shift: [-kxo, +kyo + pcb_outline_padding_top]
        - ref: matrix_ring_top
          shift: [+kxo, +kyo + pcb_outline_padding_top]

        # Middle
        - ref: matrix_middle_top
          shift: [-kxo, +kyo + pcb_outline_padding_top]
        - ref: matrix_middle_top
          shift: [+kxo, +kyo + pcb_outline_padding_top]

        # Index
        - ref: matrix_index_top
          shift: [-kxo, +kyo + pcb_outline_padding_top]
        - ref: matrix_index_top
          shift: [+kxo, +kyo + pcb_outline_padding_top]

        # Inner
        - ref: matrix_inner_top
          shift: [-kxo, +kyo + pcb_outline_padding_top]
        - ref: matrix_inner_top
          shift: [+kxo, +kyo + pcb_outline_padding_top]

        # Controller
        - ref: mcu
          shift: [-mcu_xo - mcu_spacing_left, +mcu_yo]
        - ref: edge_mcu_top_right

        # Right Side
        # Inner Thumb
        - ref: edge_thumb_cluster_top
          shift: [0, 0]
        - ref: edge_thumb_cluster_bottom
          shift: [0, 0]

        # Bottom
        # Inner thumb
        - ref: thumbs_home_cluster
          shift: [+kxo, -kyo - pcb_outline_padding_bottom]

        # Outer Thumb
        - ref: thumbs_outer_cluster
          shift: [-kxo, -kyo - pcb_outline_padding_bottom]

        # Pinky y and ring x
        - ref: matrix_pinky_bottom
          shift: [kxo + 1kx, -kyo - pcb_outline_padding_bottom]

        # Outer
        - ref: matrix_outer_bottom
          shift: [-kxo - pcb_outline_padding_left, -kyo - pcb_outline_padding_bottom]

  # Combination preview showing outline and keys.
  combo:
    - name: board
    - operation: subtract
      name: keys
```

## Run ergogen
Run ergogen on the folder with the config... `ergogen ./your_dir/ -o ./your_dir/output -d`.

Check the `debug/output/pcbs/intersect_test.kicad_pcb` kicad file.