### PR TITLE
Add point as a parameter to footprints

### DIFF
--- a/src/pcbs.js
+++ b/src/pcbs.js
@@ -258,6 +258,7 @@ const footprint = exports._footprint = (points, net_indexer, component_indexer, 
     parsed_params.ref_hide = extra.references ? '' : 'hide'
 
     // footprint positioning
+    parsed_params.point = point
     parsed_params.x = point.x
     parsed_params.y = -point.y
     parsed_params.r = point.r


### PR DESCRIPTION
Hi,

this PR adds the point object as a parameter to footprints.

I have found use for this data in several footprints now. Here are a few examples...

## Access to the raw x and y coordinates that are not a string
In some footprints it is necessary to make some calculations on the raw coordinates, but currently only the text string of both coordinates is available.

I have been working around it by parsing the `p.at` parameter [like this](https://github.com/infused-kim/kb_ergogen_fp/blob/63bde76e49b629fbeb7ebcc90609478d9c991048/nice_nano_pretty.js#L103):
```js
      const get_at_coordinates = () => {
        const pattern = /\(at (-?[\d\.]*) (-?[\d\.]*) (-?[\d\.]*)\)/;
        const matches = p.at.match(pattern);
        if (matches && matches.length == 4) {
          return [parseFloat(matches[1]), parseFloat(matches[2]), parseFloat(matches[3])];
        } else {
          return null;
        }
      }
```

But it would be much better to have access to the raw coordinates.

The easiest way to add this would be to add the `x` and `y` parameters, but today I found a use for the other metadata within the point object...

## Use the point name in the footprint
Inspired by [this conversation on discord](https://discord.com/channels/714176584269168732/759825860617437204/1130136608822276208), I created [a footprint that shows the location of points with their orientation](https://github.com/infused-kim/kb_ergogen_fp/blob/main/point_debugger.js).
<img width="626" alt="Point debugger example" src="https://github.com/ergogen/ergogen/assets/7404004/271fb931-b53d-43e8-bdc2-068b62e622b4">

But it was hard to tell which point is which. So, I wanted to add the name of the point.

While I could just add the name, I think there is a lot of other useful information in the point object that could be useful for future footprints.
