### PR TITLE
Allow boolean footprint parameters to accept 1 and 0 in addition to "true" and "false"

### DIFF
--- a/src/pcbs.js
+++ b/src/pcbs.js
@@ -227,7 +227,7 @@ const footprint = exports._footprint = (points, net_indexer, component_indexer, 
         const converters = {
             string: v => v,
             number: v => a.sane(v, `${name}.params.${param_name}`, 'number')(units),
-            boolean: v => v === 'true',
+            boolean: v => v === 'true' || a.mathnum(v)(units) === 1,
             array: v => yaml.load(v),
             object: v => yaml.load(v),
             net: v => v,


### PR DESCRIPTION
Hi,

this PR adds support to express boolean footprint parameters as 1 and 0. This is useful when you want to use a unit as a boolean parameter to make configuration easier.

Example..
```yaml
units:
    # Adjustments for keys around trackpoint mount
    cfg_tp_key_index_top_hotswap: 1
    cfg_tp_key_index_top_rotation: 180

pcb:
  keyb:
    footprints:
      choc_tp_index_top:
        what: infused-kim/choc
        where: matrix_index_top
        params:
          reverse: true
          hotswap: tp_key_index_top_hotswap  # Uses 1 from unit instead of "true"
          solder: true
          show_keycaps: true
          keycaps_x: keycaps_x
          keycaps_y: keycaps_y
          from: "{{column_net}}"
          to: "{{colrow}}"
        adjust:
          shift: [0,0]
          rotate: tp_key_index_top_rotation
```