### PR TITLE
Improved 'net' support for footprints Params Api/Interface

### DIFF
--- a/src/pcbs.js
+++ b/src/pcbs.js
@@ -238,6 +238,14 @@ const footprint = exports._footprint = (points, net_indexer, component_indexer, 
             value = u.template(value, point.meta)
             value = converters[type](value)
         }
+        if (a.type(value)() == 'array') {
+            value = value.map(item_value => {
+                if (a.type(item_value)() =='string') {
+                    item_value = u.template(item_value, point.meta)
+                }
+                return item_value
+            })
+        }
 
         // type-specific postprocessing
         if (['string', 'number', 'boolean', 'array', 'object'].includes(type)) {


### PR DESCRIPTION
#### Add 'global_net' to params structure for access (read and read/write) to global nets in footprints

This PR adds to the footprint api, through the params structure, access to the global nets, in a similar way the `local_net` allows access-to/generation-of footprint local nets.

The signature is `global_net(net, add_if_missing)`, so it provides either read-only access if `'add_if_missing'` is `false` to avoid mistakes when specifying nets and creating them, which could be hard to track, or creation as is the case also with `local_net` if the `add_if_missing` is set to `true`.

#### Add same string param templating to string elements of array params for footprints


String parameters to footprints go through templating to replace templates like `{{colrow}}` to the proper values. This is currently not done to elements of array params, which doesn't allow specifying nets in a dynamic way on arrays elements. This commit takes care of that.


---
What is this all good for? I need it for progressing with my `router` footprint. 
In short, this plugin allows ergogen to route repetitive footprints (keys) or unchanging areas, to reduce meaningfully the amount of manual routing required. 

See https://github.com/yanshay/ergogen-stuff/blob/main/docs/router.md for more details.

I'd really appreciate if it could be quickly merged so I can progress with the `router` footprint. I want to build a complete system to considerably simplify routing and this is a first step to that.