### PR TITLE
Add ability to generate circles from 3 points

### DIFF
--- a/src/anchor.js
+++ b/src/anchor.js
@@ -2,6 +2,7 @@ const u = require('./utils')
 const a = require('./assert')
 const Point = require('./point')
 const m = require('makerjs')
+const mathjs = require('mathjs')
 
 const mirror_ref = exports.mirror = (ref, mirror=true) => {
     if (mirror) {
@@ -63,6 +64,27 @@ const aggregators = {
         )
 
         return intersection_point
+    },
+    midpoint: (config, name, parts) => {
+        a.unexpected(config, name, aggregator_common)
+        a.assert(parts.length==3, `Midpoint expects exactly three parts, but it got ${parts.length}!`)
+
+        const p0dot = mathjs.dot(parts[0].p, parts[0].p)
+        const p1dot = mathjs.dot(parts[1].p, parts[1].p)
+        const p2dot = mathjs.dot(parts[2].p, parts[2].p)
+
+        const p01 = mathjs.subtract(parts[0].p, parts[1].p)
+        const p02 = mathjs.subtract(parts[0].p, parts[2].p)
+
+        const A = [p01, p02]
+        const B = [p0dot - p1dot, p0dot - p2dot]
+
+        // should get div by 0 or some such if point are colinear
+        const midpoint = mathjs.multiply(0.5, mathjs.multiply(mathjs.inv(A), B))
+
+        return new Point(
+            midpoint[0], midpoint[1], 0
+        )
     },
 }
 

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -80,7 +80,12 @@ const aggregators = {
         const B = [p0dot - p1dot, p0dot - p2dot]
 
         // should get div by 0 or some such if point are colinear
-        const midpoint = mathjs.multiply(0.5, mathjs.multiply(mathjs.inv(A), B))
+        let midpoint;
+        try {
+            midpoint = mathjs.multiply(0.5, mathjs.multiply(mathjs.inv(A), B))
+        } catch (e) {
+            a.assert(false, `Midpoint failed to compute, points are likely co-linear`)
+        }
 
         return new Point(
             midpoint[0], midpoint[1], 0

--- a/test/unit/anchor.js
+++ b/test/unit/anchor.js
@@ -9,6 +9,7 @@ describe('Anchor', function() {
         rotated_o: new Point(0, 0, 90, {label: 'rotated_o'}),
         o_five: new Point(0, 5, 0, {label: 'o_five'}),
         five_o: new Point(5, 0, 0, {label: 'five_o'}),
+        minus_five_o: new Point(-5, 0, 0, {label: 'minus_five_o'}),
         five: new Point(5, 5, 90, {label: 'five'}),
         ten: new Point(10, 10, -90, {label: 'ten'}),
         mirror_ten: new Point(-10, 10, 90, {mirrored: true})
@@ -148,6 +149,50 @@ describe('Anchor', function() {
                 method: 'intersect'
             }
         }, 'name', points).should.throw(`Intersect expects exactly two parts, but it got 0!`)
+    })
+
+    it('midpoint', function() {
+        // midpoint at origin
+        check(
+            parse({
+                aggregate: {
+                    parts: ['o_five','five_o', 'minus_five_o'],
+                    method: 'midpoint'
+                }
+            }, 'name', points)(),
+            [0, 0, 0, {}]
+        )
+
+        // co-linear points
+        parse({
+            aggregate: {
+                parts: ['o','five', 'ten'],
+                method: 'midpoint'
+            }
+        }, 'name', points).should.throw(`Midpoint failed to compute, points are likely co-linear`)
+
+        // more than two parts
+        parse({
+            aggregate: {
+                parts: ['o', `five`, `ten`, `o_five`],
+                method: 'midpoint'
+            }
+        }, 'name', points).should.throw(`Midpoint expects exactly three parts, but it got 4!`)
+
+        // only one part
+        parse({
+            aggregate: {
+                parts: ['o'],
+                method: 'midpoint'
+            }
+        }, 'name', points).should.throw(`Midpoint expects exactly three parts, but it got 1!`)
+
+        // no parts
+        parse({
+            aggregate: {
+                method: 'midpoint'
+            }
+        }, 'name', points).should.throw(`Midpoint expects exactly three parts, but it got 0!`)
     })
 
     it('shift', function() {


### PR DESCRIPTION
# Overview
The goal of this PR is to simplify the use of circles as arcs in outlining. This is useful for creating boards with curved edges systematically.
# Changes
- Added an option for the circle outline to accept an anchor in the `radius` param.
  - When used, the radius is set such that this anchor point is always on the edge of the circle.
- Added a new 'midpoint' aggregator that aggregates 3 points into one point that is equidistant to the 3 inputs.
- TODO: tests for the new functions
# Examples
Here's a snippets from my in progress `config.yaml`:
```
      what: circle
      adjust:
        aggregate:
          method: midpoint
          parts:
            - ref: matrix_pinky_bottom
              shift: [-0.5kx - 0.5px, -0.5ky - 0.5py]
            - ref: thumbfan_far_thumb
              shift: [0.5kx - 0.5px, -0.5ky - 0.5py]
            - ref: thumbfan_near_thumb
              shift: [-0.5 kx - px, -0.5 ky - py]
      radius:
        ref: matrix_pinky_bottom
        shift: [-0.5kx - 0.5px, -0.5ky - 0.5py]
```
This results in the bottom edge here:
![image](https://github.com/ergogen/ergogen/assets/56003701/c43e51f2-5b54-49f5-b35e-3f9d8fd55337)

