### PR TITLE
Allows more than one via

### DIFF
--- a/src/footprints/via.js
+++ b/src/footprints/via.js
@@ -4,13 +4,14 @@
 
 module.exports = {
     params: {
+      designator: 'V',
       net: undefined
     },
     body: p => `
       (module VIA-0.6mm (layer F.Cu) (tedit 591DBFB0)
       ${p.at /* parametric position */}   
       ${'' /* footprint reference */}
-      (fp_text reference REF** (at 0 1.4) (layer F.SilkS) hide (effects (font (size 1 1) (thickness 0.15))))
+      (fp_text reference "${p.ref}" (at 0 1.4) (layer F.SilkS) hide (effects (font (size 1 1) (thickness 0.15))))
       (fp_text value VIA-0.6mm (at 0 -1.4) (layer F.Fab) hide (effects (font (size 1 1) (thickness 0.15))))
 
       ${'' /* via */}


### PR DESCRIPTION
The .kicad_pcb file seems to be invalid if you have two vias with a REF** reference

This change puts in a dynamic reference and defaults the designator to V