### PR TITLE
Clean output dir instead of removing it

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -164,7 +164,7 @@ const composite = (data, rel) => {
 
 if (args.clean) {
     console.log('Cleaning output folder...')
-    fs.removeSync(args.o)
+    fs.emptyDirSync(args.o)
 }
 
 console.log('Writing output to disk...')


### PR DESCRIPTION
rationally is as follows

I'm running ergogen in docker and mounting output/ dir as external volume.
When --clean is up ergogen is trying to `.removeSync()` whole output dir and fails miserably.

Instead of `.removeSync()` why not use `.emptyDirSync()`.