### PR TITLE
Allow config YAML file to end in .yml

### DIFF
--- a/src/io.js
+++ b/src/io.js
@@ -22,7 +22,7 @@ const fake_require = exports.fake_require = injection => name => {
 exports.unpack = async (zip) => {
 
     // main config text (has to be called "config.ext" where ext is one of yaml/json/js)
-    const candidates = zip.file(/^config\.(yaml|json|js)$/)
+    const candidates = zip.file(/^config\.(ya?ml|json|js)$/)
     if (candidates.length != 1) {
         throw new Error('Ambiguous config in bundle!')
     }


### PR DESCRIPTION
This allows io.js to recognize the config file even if it's named `config.yml` instead of `config.yaml`.