### PR TITLE
Allow more diode footprints alternatives

### DIFF
--- a/src/footprints/diode.js
+++ b/src/footprints/diode.js
@@ -1,20 +1,34 @@
 module.exports = {
-    params: {
-        designator: 'D',
-        from: undefined,
-        to: undefined
-    },
-    body: p => `
-  
-    (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
+  params: {
+    designator: 'D',
+    from: undefined,
+    to: undefined,
+    tht: true,
+    smd: true
+  },
+  body: p => {
+    // SMD pads on both sides: SOD-123 footprint
+    const smdPads = p.smd ? `
+      (pad 1 smd rect (at -1.65 0 ${p.r}) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) ${p.to})
+      (pad 2 smd rect (at 1.65 0 ${p.r}) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) ${p.from})
+      (pad 1 smd rect (at -1.65 0 ${p.r}) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) ${p.to})
+      (pad 2 smd rect (at 1.65 0 ${p.r}) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) ${p.from})
+    ` : '';
 
+    // THT terminals
+    const thtTerminals = p.tht ? `
+      (pad 1 thru_hole rect (at -3.81 0 ${p.r}) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) ${p.to})
+      (pad 2 thru_hole circle (at 3.81 0 ${p.r}) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) ${p.from})
+    ` : '';
 
+    return `
+      (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
         ${p.at /* parametric position */}
 
         ${'' /* footprint reference */}
         (fp_text reference "${p.ref}" (at 0 0) (layer F.SilkS) ${p.ref_hide} (effects (font (size 1.27 1.27) (thickness 0.15))))
         (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
-        
+
         ${''/* diode symbols */}
         (fp_line (start 0.25 0) (end 0.75 0) (layer F.SilkS) (width 0.1))
         (fp_line (start 0.25 0.4) (end -0.35 0) (layer F.SilkS) (width 0.1))
@@ -30,17 +44,10 @@ module.exports = {
         (fp_line (start -0.35 0) (end -0.35 0.55) (layer B.SilkS) (width 0.1))
         (fp_line (start -0.35 0) (end -0.35 -0.55) (layer B.SilkS) (width 0.1))
         (fp_line (start -0.75 0) (end -0.35 0) (layer B.SilkS) (width 0.1))
-    
-        ${''/* SMD pads on both sides */}
-        (pad 1 smd rect (at -1.65 0 ${p.r}) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) ${p.to})
-        (pad 2 smd rect (at 1.65 0 ${p.r}) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) ${p.from})
-        (pad 1 smd rect (at -1.65 0 ${p.r}) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) ${p.to})
-        (pad 2 smd rect (at 1.65 0 ${p.r}) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) ${p.from})
-        
-        ${''/* THT terminals */}
-        (pad 1 thru_hole rect (at -3.81 0 ${p.r}) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) ${p.to})
-        (pad 2 thru_hole circle (at 3.81 0 ${p.r}) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) ${p.from})
-    )
-  
-    `
+
+        ${smdPads}
+        ${thtTerminals}
+      )
+    `;
+  }
 }

--- a/src/footprints/diode.js
+++ b/src/footprints/diode.js
@@ -4,7 +4,8 @@ module.exports = {
     from: undefined,
     to: undefined,
     tht: true,
-    smd: true
+    smd: true,
+    internalVia: false
   },
   body: p => {
     // SMD pads on both sides: SOD-123 footprint
@@ -19,6 +20,12 @@ module.exports = {
     const thtTerminals = p.tht ? `
       (pad 1 thru_hole rect (at -3.81 0 ${p.r}) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) ${p.to})
       (pad 2 thru_hole circle (at 3.81 0 ${p.r}) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) ${p.from})
+    ` : '';
+
+    // Internal vias
+    const internalVias = p.internalVia ? `
+      (pad 1 thru_hole circle (at -0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) ${p.to})
+      (pad 2 thru_hole circle (at 0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) ${p.from})
     ` : '';
 
     return `
@@ -47,6 +54,7 @@ module.exports = {
 
         ${smdPads}
         ${thtTerminals}
+        ${internalVias}
       )
     `;
   }

--- a/src/footprints/diode.js
+++ b/src/footprints/diode.js
@@ -5,7 +5,7 @@ module.exports = {
     to: undefined,
     tht: true,
     smd: true,
-    internalVia: false
+    via: 'none',
   },
   body: p => {
     // SMD pads on both sides: SOD-123 footprint
@@ -22,11 +22,19 @@ module.exports = {
       (pad 2 thru_hole circle (at 3.81 0 ${p.r}) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) ${p.from})
     ` : '';
 
-    // Internal vias
-    const internalVias = p.internalVia ? `
-      (pad 1 thru_hole circle (at -0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) ${p.to})
-      (pad 2 thru_hole circle (at 0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) ${p.from})
-    ` : '';
+    // Vias
+    let vias = '';
+    if (p.via === 'pad') {
+      vias = `
+        (pad 1 thru_hole circle (at -1.65 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) ${p.to})
+        (pad 2 thru_hole circle (at 1.65 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) ${p.from})
+      `;
+    } else if (p.via === 'middle') {
+      vias = `
+        (pad 1 thru_hole circle (at -0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) ${p.to})
+        (pad 2 thru_hole circle (at 0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) ${p.from})
+      `;
+    }
 
     return `
       (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
@@ -54,7 +62,7 @@ module.exports = {
 
         ${smdPads}
         ${thtTerminals}
-        ${internalVias}
+        ${vias}
       )
     `;
   }

--- a/test/footprints/diode.yaml
+++ b/test/footprints/diode.yaml
@@ -22,11 +22,20 @@ pcbs.pcb.footprints:
       smd: true
       tht: false
 
-  # SMD with vias
+  # SMD with middle vias
   - what: diode
     params:
       from: from
       to: to
       smd: true
       tht: false
-      internalVia: true
+      via: middle
+
+  # SMD with vias in pads
+  - what: diode
+    params:
+      from: from
+      to: to
+      smd: true
+      tht: false
+      via: pad

--- a/test/footprints/diode.yaml
+++ b/test/footprints/diode.yaml
@@ -21,3 +21,12 @@ pcbs.pcb.footprints:
       to: to
       smd: true
       tht: false
+
+  # SMD with vias
+  - what: diode
+    params:
+      from: from
+      to: to
+      smd: true
+      tht: false
+      internalVia: true

--- a/test/footprints/diode.yaml
+++ b/test/footprints/diode.yaml
@@ -1,6 +1,23 @@
 points.zones.matrix:
 pcbs.pcb.footprints:
+  # base
   - what: diode
     params:
       from: from
       to: to
+
+  # THT only
+  - what: diode
+    params:
+      from: from
+      to: to
+      smd: false
+      tht: true
+
+  # SMD only
+  - what: diode
+    params:
+      from: from
+      to: to
+      smd: true
+      tht: false

--- a/test/footprints/diode___pcbs_pcb.kicad_pcb
+++ b/test/footprints/diode___pcbs_pcb.kicad_pcb
@@ -243,9 +243,46 @@
     
         
         
-      (pad 1 thru_hole circle (at -0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) (net 2 "to"))
-      (pad 2 thru_hole circle (at 0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) (net 1 "from"))
+        (pad 1 thru_hole circle (at -0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) (net 2 "to"))
+        (pad 2 thru_hole circle (at 0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) (net 1 "from"))
+      
+      )
     
+
+      (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
+        (at 0 0 0)
+
+        
+        (fp_text reference "D5" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
+        (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
+
+        
+        (fp_line (start 0.25 0) (end 0.75 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 0.4) (end -0.35 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end 0.25 -0.4) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 0.55) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 -0.55) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.75 0) (end -0.35 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 0) (end 0.75 0) (layer B.SilkS) (width 0.1))
+        (fp_line (start 0.25 0.4) (end -0.35 0) (layer B.SilkS) (width 0.1))
+        (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end 0.25 -0.4) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 0.55) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 -0.55) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.75 0) (end -0.35 0) (layer B.SilkS) (width 0.1))
+
+        
+      (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 2 "to"))
+      (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 1 "from"))
+      (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 2 "to"))
+      (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 1 "from"))
+    
+        
+        
+        (pad 1 thru_hole circle (at -1.65 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) (net 2 "to"))
+        (pad 2 thru_hole circle (at 1.65 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) (net 1 "from"))
+      
       )
     
   

--- a/test/footprints/diode___pcbs_pcb.kicad_pcb
+++ b/test/footprints/diode___pcbs_pcb.kicad_pcb
@@ -109,16 +109,13 @@
   )
 
   
-  
-    (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
-
-
+      (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
         (at 0 0 0)
 
         
         (fp_text reference "D1" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
         (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
-        
+
         
         (fp_line (start 0.25 0) (end 0.75 0) (layer F.SilkS) (width 0.1))
         (fp_line (start 0.25 0.4) (end -0.35 0) (layer F.SilkS) (width 0.1))
@@ -134,18 +131,82 @@
         (fp_line (start -0.35 0) (end -0.35 0.55) (layer B.SilkS) (width 0.1))
         (fp_line (start -0.35 0) (end -0.35 -0.55) (layer B.SilkS) (width 0.1))
         (fp_line (start -0.75 0) (end -0.35 0) (layer B.SilkS) (width 0.1))
+
+        
+      (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 2 "to"))
+      (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 1 "from"))
+      (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 2 "to"))
+      (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 1 "from"))
     
         
-        (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 2 "to"))
-        (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 1 "from"))
-        (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 2 "to"))
-        (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 1 "from"))
+      (pad 1 thru_hole rect (at -3.81 0 0) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) (net 2 "to"))
+      (pad 2 thru_hole circle (at 3.81 0 0) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) (net 1 "from"))
+    
+      )
+    
+
+      (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
+        (at 0 0 0)
+
+        
+        (fp_text reference "D2" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
+        (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
+
+        
+        (fp_line (start 0.25 0) (end 0.75 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 0.4) (end -0.35 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end 0.25 -0.4) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 0.55) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 -0.55) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.75 0) (end -0.35 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 0) (end 0.75 0) (layer B.SilkS) (width 0.1))
+        (fp_line (start 0.25 0.4) (end -0.35 0) (layer B.SilkS) (width 0.1))
+        (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end 0.25 -0.4) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 0.55) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 -0.55) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.75 0) (end -0.35 0) (layer B.SilkS) (width 0.1))
+
         
         
-        (pad 1 thru_hole rect (at -3.81 0 0) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) (net 2 "to"))
-        (pad 2 thru_hole circle (at 3.81 0 0) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) (net 1 "from"))
-    )
-  
+      (pad 1 thru_hole rect (at -3.81 0 0) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) (net 2 "to"))
+      (pad 2 thru_hole circle (at 3.81 0 0) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) (net 1 "from"))
+    
+      )
+    
+
+      (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
+        (at 0 0 0)
+
+        
+        (fp_text reference "D3" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
+        (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
+
+        
+        (fp_line (start 0.25 0) (end 0.75 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 0.4) (end -0.35 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end 0.25 -0.4) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 0.55) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 -0.55) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.75 0) (end -0.35 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 0) (end 0.75 0) (layer B.SilkS) (width 0.1))
+        (fp_line (start 0.25 0.4) (end -0.35 0) (layer B.SilkS) (width 0.1))
+        (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end 0.25 -0.4) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 0.55) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 -0.55) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.75 0) (end -0.35 0) (layer B.SilkS) (width 0.1))
+
+        
+      (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 2 "to"))
+      (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 1 "from"))
+      (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 2 "to"))
+      (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 1 "from"))
+    
+        
+      )
     
   
 

--- a/test/footprints/diode___pcbs_pcb.kicad_pcb
+++ b/test/footprints/diode___pcbs_pcb.kicad_pcb
@@ -142,6 +142,7 @@
       (pad 1 thru_hole rect (at -3.81 0 0) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) (net 2 "to"))
       (pad 2 thru_hole circle (at 3.81 0 0) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) (net 1 "from"))
     
+        
       )
     
 
@@ -173,6 +174,7 @@
       (pad 1 thru_hole rect (at -3.81 0 0) (size 1.778 1.778) (drill 0.9906) (layers *.Cu *.Mask) (net 2 "to"))
       (pad 2 thru_hole circle (at 3.81 0 0) (size 1.905 1.905) (drill 0.9906) (layers *.Cu *.Mask) (net 1 "from"))
     
+        
       )
     
 
@@ -206,6 +208,44 @@
       (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 1 "from"))
     
         
+        
+      )
+    
+
+      (module ComboDiode (layer F.Cu) (tedit 5B24D78E)
+        (at 0 0 0)
+
+        
+        (fp_text reference "D4" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
+        (fp_text value "" (at 0 0) (layer F.SilkS) hide (effects (font (size 1.27 1.27) (thickness 0.15))))
+
+        
+        (fp_line (start 0.25 0) (end 0.75 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 0.4) (end -0.35 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end 0.25 -0.4) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 0.55) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 -0.55) (layer F.SilkS) (width 0.1))
+        (fp_line (start -0.75 0) (end -0.35 0) (layer F.SilkS) (width 0.1))
+        (fp_line (start 0.25 0) (end 0.75 0) (layer B.SilkS) (width 0.1))
+        (fp_line (start 0.25 0.4) (end -0.35 0) (layer B.SilkS) (width 0.1))
+        (fp_line (start 0.25 -0.4) (end 0.25 0.4) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end 0.25 -0.4) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 0.55) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.35 0) (end -0.35 -0.55) (layer B.SilkS) (width 0.1))
+        (fp_line (start -0.75 0) (end -0.35 0) (layer B.SilkS) (width 0.1))
+
+        
+      (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 2 "to"))
+      (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 1 "from"))
+      (pad 1 smd rect (at -1.65 0 0) (size 0.9 1.2) (layers B.Cu B.Paste B.Mask) (net 2 "to"))
+      (pad 2 smd rect (at 1.65 0 0) (size 0.9 1.2) (layers F.Cu F.Paste F.Mask) (net 1 "from"))
+    
+        
+        
+      (pad 1 thru_hole circle (at -0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) (net 2 "to"))
+      (pad 2 thru_hole circle (at 0.45 0) (size 0.6 0.6) (drill 0.3) (layers *.Cu) (net 1 "from"))
+    
       )
     
   


### PR DESCRIPTION
## Changes

- Allow diode SMD/THT footprints to be disabled
- Add `internalVia` option to diodes to include vias between SMD pads
- Updated diode snapshot tests

## Motivation

- I did not need or want through hole terminals for my diodes as part of my keyboard, so I added the option to disable them (or the SMD pads)
- Additionally I found a lot of nice utility with vias next to the SMD pads, so I added an addition `internalVia` option

## Footprints

| Settings | Footprint |
| --- | --- |
| Default (same as current default) | ![CleanShot 2024-07-19 at 22 37 30](https://github.com/user-attachments/assets/f6e1c37d-08f6-409d-956f-8ca35ac76de5) |
| THT only | ![CleanShot 2024-07-19 at 22 38 07](https://github.com/user-attachments/assets/26145d29-930d-48c9-94e6-c146c4663d25) |
| SMD only | ![CleanShot 2024-07-19 at 22 38 31](https://github.com/user-attachments/assets/7efee1c8-96b4-4c04-a8d2-6c267a4446fe) |
| SMD with vias | ![CleanShot 2024-07-19 at 22 38 58](https://github.com/user-attachments/assets/8c5f62c2-840a-4d45-8f71-990b6cd82bf8) |
| SMD with vias in pad | ![CleanShot 2024-07-19 at 23 19 58](https://github.com/user-attachments/assets/c78a3fd7-5536-4ab9-9c44-5441d20f6f9b) |
