### PR TITLE
Ergogen 4.2.0 - Combined code PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Until there's a proper "Getting started" guide, try getting acquainted with **Er
     [![Button Official]][WebUI]   
     [![Button Unofficial]][Unofficial]
    
-    The unofficial deployment is probably better, tbh, and will soon be replacing the official one.
     Choose either one, then click things, look at outputs and see if things start to make sense.
    
     There is no need for you to download the **CLI** unless you want to do one of the following:


### PR DESCRIPTION
This Pull Request is going to combine changes from a number of independent PRs and fixes:

- [x] Add `hull` outline: [pull 148](https://github.com/ergogen/ergogen/pull/148)
- [x] Fix KLE import: [pull 146](https://github.com/ergogen/ergogen/pull/146) and [pull 29](https://github.com/ergogen/ergogen/pull/29) (closes https://github.com/ergogen/ergogen/issues/94)
- [x] Updated versioning: [pull 149](https://github.com/ergogen/ergogen/pull/149)
- [x] Allow YAML files to have *.yml extension: [pull 133](https://github.com/ergogen/ergogen/pull/133)
- [x] Clean output dir instead of removing it: [pull 131](https://github.com/ergogen/ergogen/pull/131)

The following fixes or features are also going to be included (they didn't have a dedicated PR):

- [x] Add `path` outline (supporting `bezier`, `arc`, `line`, `s_curve`) - With the `arc` option, it's now possible to address the need outlined in https://github.com/ergogen/ergogen/pull/110 without a dedicated `midpoint` aggregate method.
- [x] Fix `rollup.config.mjs` (use Node 20+ import syntax)
- [x] Fix how variables are resolved in mirror properties: Previously, when a variable was used for a property inside a `mirror` configuration (e.g., `width: my_var`), it was not resolved correctly. This was because the sanitization and variable resolution process was not re-applied after the mirrored point's metadata was extended with the mirror configuration. The issue is fixed by passing the `units` object to the `perform_mirror` function and re-sanitizing properties like `width` and `height` if they are overridden in the mirror config. A new test case is added to verify that variables in mirror properties are now correctly resolved. Closes https://github.com/ergogen/ergogen/issues/145
- [x] Generate SVG also when `--debug` is not passed