### PR TITLE
Migrate from kle-serial to kle-serial2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "hull": "github:andriiheonia/hull",
                 "js-yaml": "^3.14.1",
                 "jszip": "^3.10.1",
-                "kle-serial": "github:ergogen/kle-serial#ergogen",
+                "kle-serial2": "github:adamws/kle-serial2",
                 "makerjs": "^0.18.1",
                 "mathjs": "^15.0.0",
                 "yargs": "^17.7.2"
@@ -65,7 +65,6 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -611,7 +610,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1184,7 +1182,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.9",
                 "caniuse-lite": "^1.0.30001746",
@@ -2179,6 +2176,7 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -2213,14 +2211,11 @@
             "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-2.0.1.tgz",
             "integrity": "sha512-9KqSdmWCkBIisFIGclT0FRagKhI7IVbMyUjsxCFG0Ly1Dg6whlxJ7b9lrq8ifk3X/fGeJzok1R75LQfZTfA5zQ=="
         },
-        "node_modules/kle-serial": {
-            "name": "@ijprest/kle-serial",
-            "version": "0.15.1",
-            "resolved": "git+ssh://git@github.com/ergogen/kle-serial.git#61f29f317d87bbfed0b0b7e646e1b91d4384ac02",
-            "license": "MIT",
-            "dependencies": {
-                "json5": "^2.1.0"
-            }
+        "node_modules/kle-serial2": {
+            "name": "@adamws/kle-serial",
+            "version": "0.18.0",
+            "resolved": "git+ssh://git@github.com/adamws/kle-serial2.git#75a2b55ef5217f3331f7504523840bccf4369991",
+            "license": "MIT"
         },
         "node_modules/lie": {
             "version": "3.3.0",
@@ -3134,7 +3129,6 @@
             "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "hull": "github:andriiheonia/hull",
         "js-yaml": "^3.14.1",
         "jszip": "^3.10.1",
-        "kle-serial": "github:ergogen/kle-serial#ergogen",
+        "kle-serial2": "github:adamws/kle-serial2",
         "makerjs": "^0.18.1",
         "mathjs": "^15.0.0",
         "yargs": "^17.7.2"

--- a/src/kle.js
+++ b/src/kle.js
@@ -1,5 +1,5 @@
 const u = require('./utils')
-const kle = require('kle-serial')
+const kle = require('kle-serial2')
 const yaml = require('js-yaml')
 
 exports.convert = (config, logger) => {


### PR DESCRIPTION
Replace the ergogen/kle-serial fork dependency with adamws/kle-serial2. This updates both the package.json dependency and the import statement in src/kle.js. All KLE-related tests pass successfully.