### PR TITLE
Add resolution setting for circles & arcs

### DIFF
--- a/src/cases.js
+++ b/src/cases.js
@@ -4,7 +4,7 @@ const o = require('./operation')
 
 exports.parse = (config, outlines, units) => {
 
-    const cases_config = a.sane(config, 'cases', 'object')()
+    const cases_config = a.sane(config.cases || {}, 'cases', 'object')()
 
     const scripts = {}
     const cases = {}
@@ -77,6 +77,7 @@ exports.parse = (config, outlines, units) => {
                     scripts[extruded_name] = m.exporter.toJscadScript(outline, {
                         functionName: `${extruded_name}_outline_fn`,
                         extrude: extrude,
+                        maxArcFacet: config.meta?.maxArcFacet,
                         indent: 4
                     })
                 }

--- a/src/ergogen.js
+++ b/src/ergogen.js
@@ -71,7 +71,7 @@ const process = async (raw, options={}, logger=()=>{}) => {
     }
 
     logger('Modeling cases...')
-    const cases = cases_lib.parse(config.cases || {}, outlines, units)
+    const cases = cases_lib.parse(config, outlines, units)
     results.cases = {}
     for (const [case_name, case_script] of Object.entries(cases)) {
         if (!debug && case_name.startsWith('_')) continue


### PR DESCRIPTION
This fixes the issue of all circles and arcs having exactly 32 segments.
This causes big circles and arcs to get jaggy when generating cases. It also causes excessive detail for most holes.

This pull request exposes the `maxArcFacet` option from jscad as a field in the meta block.
This setting is backwards compatible and only activates when you assign the `meta.maxArcFacet`.

As a potential note for the docs:
A decent `maxArcFacet` value for me has been 0.25mm to get good detail.