### PR TITLE
Adjust mx footprint pad 2 SMD x-offset to 5.815

### DIFF
--- a/src/footprints/mx.js
+++ b/src/footprints/mx.js
@@ -63,7 +63,7 @@ module.exports = {
         
         ${'' /* net pads */}
         (pad 1 smd rect (at ${def_neg}7.085 -2.54 ${p.r}) (size 2.55 2.5) (layers ${def_side}.Cu ${def_side}.Paste ${def_side}.Mask) ${p.from})
-        (pad 2 smd rect (at ${def_pos}5.842 -5.08 ${p.r}) (size 2.55 2.5) (layers ${def_side}.Cu ${def_side}.Paste ${def_side}.Mask) ${p.to})
+        (pad 2 smd rect (at ${def_pos}5.815 -5.08 ${p.r}) (size 2.55 2.5) (layers ${def_side}.Cu ${def_side}.Paste ${def_side}.Mask) ${p.to})
         `
       } else {
           return `


### PR DESCRIPTION
The distance between the centers of the left hole <-> pad, are different from the distance of the centers of the right hole <-> pad.


<img width="756" height="366" alt="image" src="https://github.com/user-attachments/assets/e585c8f6-3c1e-4455-8e0d-6cf7247c42c6" />

Based on the image above, the "foots" are starting at a distance of (11.30 / 2) = 5.65mm (a) from the center of the drawing on the x.

The width of both "foot" is 14.50 - 11.30 = 3.2mm. Hence the width of each one is 3.2/2 = 1.6mm (b)

Hence the middle of the "foots" are at 5.65mm + 1.6/2  = 6.45mm. (c)

<img width="1690" height="1384" alt="image" src="https://github.com/user-attachments/assets/5e4668f2-c9f0-43e3-87c1-30100d0d275b" />

Based on the drawing above, the center of the Kailh, is offset by 0.05" / 2 = 0.025" = 0.635mm(d). The left hole is at -1.5" and the right is at 1.0".


That means the center of the left pad, centered for the mx footpring, should be at -(c)  - (d) = -6.45 - 0.635 = -7.085mm. *This matches what we have for the left pad.

For the right pad, the center, centered for the mx footprint, should be at (c) - (d) = 6.45 - 0.635 = 5.815mm

(I just used Claude to create do the commit and PR, the calculation above are done manually and double-checked. But please also double check before merging)

Links:
http://www.kailh.com/en/Products/Ks/HPC/CPG151101S11-16.pdf
https://cdn.sparkfun.com/datasheets/Components/Switches/MX%20Series.pdf